### PR TITLE
fix: Improve filtering logic for documentation change detection in CI…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,8 @@ jobs:
             # Remove common timestamp patterns and compare
             # Filter out lines that contain only timestamp-related changes
             FILTERED_DIFF=$(mktemp)
-            cat "$TEMP_DIFF" | grep -v -E "(generated|timestamp|date|time)" > "$FILTERED_DIFF" || true
+            cat "$TEMP_DIFF" | grep -iv -E "(generated|timestamp|date|time)" > \
+              "$FILTERED_DIFF" || true
 
             # Check if filtered diff has meaningful content
             if [ -s "$FILTERED_DIFF" ]; then


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/main.yml` file to improve the filtering of timestamp-related changes in the workflow.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L75-R76): Updated the `grep` command to use the `-i` flag for case-insensitive matching when filtering out timestamp-related changes.