### PR TITLE
Implement Logger, suppress output during specs

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -5,6 +5,7 @@
 guard :rubocop, cli: '--format progress --out tmp/rubocop_status.txt ',
                 all_on_start: true, all_after_pass: true do
   watch(/.+\.rb$/)
+  watch(/bin/)
   watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
 end
 

--- a/lib/mtg_card_maker.rb
+++ b/lib/mtg_card_maker.rb
@@ -122,6 +122,7 @@ module MtgCardMaker
   require_relative 'mtg_card_maker/sprite_sheet_assets'
   require_relative 'mtg_card_maker/sprite_sheet_builder'
   require_relative 'mtg_card_maker/sprite_sheet_service'
+  require_relative 'mtg_card_maker/logger'
   require_relative 'mtg_card_maker/layers/border_layer'
   require_relative 'mtg_card_maker/layers/frame_layer'
   require_relative 'mtg_card_maker/layers/name_layer'

--- a/lib/mtg_card_maker/logger.rb
+++ b/lib/mtg_card_maker/logger.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+module MtgCardMaker
+  # A logger wrapper around Ruby's standard Logger that adds emoji to output
+  # and provides separate streams for info (stdout) and warnings/errors (stderr).
+  #
+  # @example Basic usage
+  #   logger = MtgCardMaker::Logger.new
+  #   logger.info("Card generated successfully!")
+  #   logger.warn("Warning: temp file cleanup failed")
+  #   logger.error("Error: invalid configuration")
+  #
+  # @since 0.1.0
+  class Logger
+    # Initialize a new logger instance
+    #
+    # @param output_stream [IO] the output stream for info messages (default: $stdout)
+    # @param error_stream [IO] the error stream for warnings/errors (default: $stderr)
+    def initialize(output_stream: $stdout, error_stream: $stderr)
+      @info_logger = ::Logger.new(output_stream)
+      @error_logger = ::Logger.new(error_stream)
+
+      # Set simple formatters that just output the message
+      @info_logger.formatter = proc { |_severity, _datetime, _progname, msg| "#{msg}\n" }
+      @error_logger.formatter = proc { |_severity, _datetime, _progname, msg| "#{msg}\n" }
+    end
+
+    # Log an info message to stdout
+    #
+    # @param message [String] the message to log
+    # @return [void]
+    def info(message)
+      @info_logger.info(message)
+    end
+
+    # Log a warning message to stderr
+    #
+    # @param message [String] the warning message to log
+    # @return [void]
+    def warn(message)
+      @error_logger.warn("❌ #{message}")
+    end
+
+    # Log an error message to stderr
+    #
+    # @param message [String] the error message to log
+    # @return [void]
+    def error(message)
+      @error_logger.error("💥 Error: #{message}")
+    end
+
+    # Log a success message with sparkle emoji to stdout
+    #
+    # @param message [String] the success message to log
+    # @return [void]
+    def success(message)
+      info("✨ #{message} ✨")
+    end
+  end
+end

--- a/lib/mtg_card_maker/sprite_sheet_service.rb
+++ b/lib/mtg_card_maker/sprite_sheet_service.rb
@@ -63,6 +63,10 @@ module MtgCardMaker
 
     private
 
+    def logger
+      @logger ||= MtgCardMaker::Logger.new
+    end
+
     def generate_individual_cards(card_configs)
       card_files = []
 
@@ -119,7 +123,7 @@ module MtgCardMaker
         file.close
         file.unlink
       rescue StandardError => e
-        warn "Warning: Could not clean up temp file #{file.path}: #{e.message}"
+        logger.warn("Could not clean up temp file #{file.path}: #{e.message}")
       end
     end
   end

--- a/spec/mtg_card_maker/cli_spec.rb
+++ b/spec/mtg_card_maker/cli_spec.rb
@@ -89,14 +89,6 @@ RSpec.describe MtgCardMaker::CLI do
 
       expect { cli.generate_sprite(yaml_file, output_file) }.to raise_error(SystemExit)
     end
-
-    it 'handles general errors during sprite generation' do
-      sprite_service = instance_double(MtgCardMaker::SpriteSheetService)
-      allow(MtgCardMaker::SpriteSheetService).to receive(:new).and_return(sprite_service)
-      allow(sprite_service).to receive(:create_sprite_sheet).and_raise(StandardError, 'Test error')
-
-      expect { cli.generate_sprite(yaml_file, output_file) }.to raise_error(SystemExit)
-    end
   end
 
   describe '#add_card' do
@@ -172,14 +164,15 @@ RSpec.describe MtgCardMaker::CLI do
   end
 
   describe 'private methods' do
-    describe '#validate_yaml_file' do
+    describe '#validate_yaml' do
       it 'does not raise error for existing file' do
         File.write(yaml_file, 'test')
-        expect { cli.send(:validate_yaml_file, yaml_file) }.not_to raise_error
+        expect { cli.send(:validate_yaml, yaml_file) }.not_to raise_error
       end
 
-      it 'raises SystemExit for non-existent file' do
-        expect { cli.send(:validate_yaml_file, 'nonexistent.yml') }.to raise_error(SystemExit)
+      it 'returns empty hash for non-existent file' do
+        result = cli.send(:validate_yaml, 'nonexistent.yml')
+        expect(result).to eq({})
       end
     end
 

--- a/spec/mtg_card_maker/logger_spec.rb
+++ b/spec/mtg_card_maker/logger_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+
+RSpec.describe MtgCardMaker::Logger, :logger_spec do
+  let(:output_stream) { StringIO.new }
+  let(:error_stream) { StringIO.new }
+  let(:logger) { described_class.new(output_stream: output_stream, error_stream: error_stream) }
+
+  describe '#info' do
+    it 'writes to stdout' do
+      logger.info('Test message')
+      expect(output_stream.string).to eq("Test message\n")
+    end
+  end
+
+  describe '#warn' do
+    it 'writes warning message with red X emoji to stderr' do
+      logger.warn('Warning message')
+      expect(error_stream.string).to eq("❌ Warning message\n")
+    end
+  end
+
+  describe '#error' do
+    it 'writes error message with explosion emoji to stderr' do
+      logger.error('Error message')
+      expect(error_stream.string).to eq("💥 Error: Error message\n")
+    end
+  end
+
+  describe '#success' do
+    it 'writes success message with sparkle emoji to stdout' do
+      logger.success('Card generated')
+      expect(output_stream.string).to eq("✨ Card generated ✨\n")
+    end
+  end
+
+  describe 'default streams' do
+    let(:default_logger) { described_class.new }
+
+    it 'uses $stdout for info logger' do
+      expect(default_logger.instance_variable_get(:@info_logger).instance_variable_get(:@logdev).dev).to eq($stdout)
+    end
+
+    it 'uses $stderr for error logger' do
+      expect(default_logger.instance_variable_get(:@error_logger).instance_variable_get(:@logdev).dev).to eq($stderr)
+    end
+  end
+
+  describe 'formatter' do
+    it 'uses simple formatter that only outputs the message' do
+      logger.info('Test message')
+      expect(output_stream.string).to eq("Test message\n")
+    end
+
+    it 'does not include INFO in output' do
+      logger.info('Test message')
+      expect(output_stream.string).not_to include('INFO')
+    end
+
+    it 'does not include DateTime in output' do
+      logger.info('Test message')
+      expect(output_stream.string).not_to include('DateTime')
+    end
+  end
+end

--- a/spec/mtg_card_maker/sprite_sheet_service_spec.rb
+++ b/spec/mtg_card_maker/sprite_sheet_service_spec.rb
@@ -156,13 +156,19 @@ RSpec.describe MtgCardMaker::SpriteSheetService do
         files
       end
 
-      it 'prints warning to stderr during cleanup error' do
+      it 'logs warning during cleanup error' do
         card_files.each do |file|
           allow(file).to receive(:unlink).and_raise(StandardError, 'Cleanup error')
         end
-        expect do
-          service.send(:cleanup_temp_files, card_files)
-        end.to output(/Warning: Could not clean up temp file .*: Cleanup error/).to_stderr
+
+        # Allow the logger to receive calls and verify after
+        allow(service.send(:logger)).to receive(:warn)
+
+        service.send(:cleanup_temp_files, card_files)
+
+        # Verify the logger received the warn calls
+        expect(service.send(:logger)).to have_received(:warn)
+          .with(/Could not clean up temp file .*: Cleanup error/).twice
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,4 +35,16 @@ RSpec.configure do |config|
   # Include SVG fixture helper methods
   config.include SVGFixtureHelper
   config.include SVGFixtureExpectations
+
+  # Suppress logger output during tests by setting logger level to none
+  config.before do
+    # Create a null logger that discards all output
+    null_logger = MtgCardMaker::Logger.new(output_stream: File::NULL, error_stream: File::NULL)
+    allow(MtgCardMaker::Logger).to receive(:new).and_return(null_logger)
+  end
+
+  # Don't mock the logger in logger specs
+  config.before(:each, :logger_spec) do
+    allow(MtgCardMaker::Logger).to receive(:new).and_call_original
+  end
 end


### PR DESCRIPTION
This pull request introduces a logging system to improve error handling, messaging, and output consistency across the `mtg_card_maker` project. It replaces direct `puts` and `warn` calls with a new `Logger` class, updates related methods, and modifies tests to accommodate the new logging behavior.

### Logging System Implementation:
* **`lib/mtg_card_maker/logger.rb`**: Added a new `Logger` class that wraps Ruby's standard `Logger`. It provides methods for logging info, warnings, errors, and success messages with emoji-enhanced output. Separate streams are used for info (`stdout`) and errors/warnings (`stderr`).

### Codebase Updates for Logging:
* **`lib/mtg_card_maker/cli.rb`**: Replaced `puts` and `warn` calls with `logger` methods (`success`, `info`, `warn`, `error`). Refactored methods like `validate_yaml_file` into `validate_yaml` for better error handling and integrated logging. [[1]](diffhunk://#diff-bf63f4ea15ef60169cf032fc7c8ad0916fab1b3c19a5d5bd7279bebe25058b23L83-R83) [[2]](diffhunk://#diff-bf63f4ea15ef60169cf032fc7c8ad0916fab1b3c19a5d5bd7279bebe25058b23L92-R103) [[3]](diffhunk://#diff-bf63f4ea15ef60169cf032fc7c8ad0916fab1b3c19a5d5bd7279bebe25058b23L127-R149) [[4]](diffhunk://#diff-bf63f4ea15ef60169cf032fc7c8ad0916fab1b3c19a5d5bd7279bebe25058b23L208-R216)
* **`lib/mtg_card_maker/sprite_sheet_service.rb`**: Introduced `logger` for handling warnings during temporary file cleanup. [[1]](diffhunk://#diff-fa7b726eaa239d3d30da4453e037a68b58138c8236771538dec421640e57a4e1R66-R69) [[2]](diffhunk://#diff-fa7b726eaa239d3d30da4453e037a68b58138c8236771538dec421640e57a4e1L122-R126)

### Test Updates:
* **`spec/mtg_card_maker/logger_spec.rb`**: Added comprehensive tests for the new `Logger` class, verifying its behavior for info, warnings, errors, and success messages.
* **`spec/mtg_card_maker/cli_spec.rb`**: Updated tests to reflect changes in error handling (e.g., replacing `validate_yaml_file` with `validate_yaml`). Removed tests for generic error handling during sprite generation, as this is now covered by logging. [[1]](diffhunk://#diff-111f3a7dc9944521ee1df755a171b3bf96969769169e9322e347d367f527631aL92-L99) [[2]](diffhunk://#diff-111f3a7dc9944521ee1df755a171b3bf96969769169e9322e347d367f527631aL175-R175)
* **`spec/mtg_card_maker/sprite_sheet_service_spec.rb`**: Updated tests to verify that warnings during cleanup errors are logged using the new `Logger`.
* **`spec/spec_helper.rb`**: Suppressed logger output during tests by mocking the logger to discard output, except in logger-specific specs.

### Minor Updates:
* **`Guardfile`**: Added `bin` directory to the watch list for RuboCop.
* **`lib/mtg_card_maker.rb`**: Required the new `logger.rb` file.