### PR TITLE
Fix docs, simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,13 +38,10 @@ assignees: ['joe-sharp']
 
 ## 📝 Checklist
 
-- [ ] I have searched existing issues to avoid
-duplicates
-- [ ] I have provided all required environment
-information
+- [ ] I have searched existing issues to avoid duplicates
+- [ ] I have provided all required environment information
 - [ ] I have included a minimal reproduction case
-- [ ] I have tested with the latest version of
-MTG Card Maker
+- [ ] I have tested with the latest version of MTG Card Maker
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,69 +6,46 @@ labels: ['bug', 'needs-triage']
 assignees: ['joe-sharp']
 ---
 
-## 🎯 Bug Description
+## 🎯 What's the problem?
 
-**Clear and concise description of what the bug is:**
+**Brief description of the bug:**
 
-## 🔍 Steps to Reproduce
+## 🔍 How to reproduce
 
-1. Run command: `mtg_card_maker ...`
-2. Use YAML configuration: `...` (If used -- paste in the "📁 Configuration Files" section below)
-3. See error: `...`
+**Steps to reproduce the behavior:**
+1. Run: `...`
+2. See: `...`
 
-## 🎴 Expected Behavior
+## 🎴 What should happen?
 
-**What you expected to happen:**
+**Expected behavior:**
 
-## ❌ Actual Behavior
+## ❌ What actually happens?
 
-**What actually happened:**
+**Actual behavior:**
 
-## 📋 Environment Information
+## 📋 Environment
 
-**Please complete the following information:**
+- **OS:** [e.g. macOS, Ubuntu, Windows]
+- **Ruby:** [e.g. 3.2.2]
+- **MTG Card Maker:** [e.g. 0.1.0]
 
-- **OS:** [e.g. macOS 14.0, Ubuntu 22.04, Windows 11]
-- **Ruby Version:** [e.g. 3.2.2, 3.5.0]
-- **MTG Card Maker Version:** [e.g. 0.1.0]
-- **Installation Method:** [e.g. `gem install`, `bundle install`, source]
-
-## 📁 Configuration Files
-
-**If applicable, include your YAML configuration:**
+## 📁 Configuration (if applicable)
 
 ```yaml
-# Your card configuration here
-name: "Example Card"
-type_line: "Creature - Human"
-rules_text: "Example rules text"
-# ... other properties
+# Your YAML config here
 ```
-
-## 🖼️ Generated Output
-
-**If applicable, attach the generated SVG file or describe the visual issue:**
-
-## 🔧 Command Line Output
-
-**Include the full command and any error messages:**
-
-## 📊 Additional Context
-
-**Add any other context about the problem here:**
-
-- **Related Issues:** [e.g. #123]
-- **Workarounds:** [e.g. "Using a different color scheme works"]
-- **Frequency:** [e.g. "Always", "Sometimes", "First time"]
 
 ## 📝 Checklist
 
-- [ ] I have searched existing issues to avoid duplicates
-- [ ] I have provided all required environment information
+- [ ] I have searched existing issues to avoid
+duplicates
+- [ ] I have provided all required environment
+information
 - [ ] I have included a minimal reproduction case
-- [ ] I have attached relevant files (SVG, YAML, error logs)
-- [ ] I have tested with the latest version of MTG Card Maker
+- [ ] I have tested with the latest version of
+MTG Card Maker
 
 ---
 
-**Note:** This is a fan-made tool for creating custom MTG cards. Please ensure your use complies with Wizards of the Coast's Fan Content Policy.
+**Note:** This is a fan-made tool for creating custom MTG cards. Please ensure your use complies with [Wizards of the Coast's Fan Content Policy.](https://company.wizards.com/en/legal/fancontentpolicy)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,6 +22,9 @@ assignees: ['joe-sharp']
 
 - [ ] I've searched existing issues to avoid duplicates
 - [ ] This aligns with MTG Card Maker's goals
+  - If unsure tell me why it should below:
+
+
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,87 +6,23 @@ labels: ['enhancement', 'needs-triage']
 assignees: ['joe-sharp']
 ---
 
-## 🎯 Feature Description
+## 🎯 What would you like to see?
 
-**A clear and concise description of what you'd like to see:**
+**Brief description of the feature:**
 
-## 🎴 Use Case
+## 🎴 Why is this useful?
 
-**Describe the problem this feature would solve:**
+**What problem does this solve or what does it enable?**
 
-- **Current Limitation:** [e.g. "Can't create split cards"]
-- **Desired Outcome:** [e.g. "Would like to create cards with split mana costs"]
+## 🖼️ Examples (optional)
 
-## 🖼️ Visual Examples
-
-**If applicable, include mockups or examples:**
-
-- **Reference Images:** [e.g. "Similar to MTG split cards"]
-- **Mockup:** [e.g. "Card should look like..."]
-- **Inspiration:** [e.g. "Based on existing MTG card types"]
-
-## 🔧 Technical Requirements
-
-**Describe the technical implementation you envision:**
-
-### New Properties
-```yaml
-# Example of new YAML properties
-name: "Split Card"
-type_line: "Instant // Sorcery"
-mana_cost: "1(RU)(RU)"
-split_cost: true
-# ... other new properties
-```
-
-### CLI Commands
-```bash
-# Example of new CLI options
-mtg_card_maker generate_card --split-cost --mana-cost="1(RU)(RU)"
-```
-
-## 🎨 Design Considerations
-
-**How should this feature integrate with existing functionality:**
-
-- **Color Schemes:** [e.g. "Should work with all existing colors"]
-- **Border Types:** [e.g. "Should support gold borders"]
-- **Sprite Sheets:** [e.g. "Should work in batch generation"]
-- **Backward Compatibility:** [e.g. "Should not break existing cards"]
-
-## 📝 Implementation Ideas
-
-**If you have technical knowledge, suggest implementation approaches:**
-
-- **File Structure:** [e.g. "New layer type for split cards"]
-- **Dependencies:** [e.g. "May need additional SVG libraries"]
-- **Testing Strategy:** [e.g. "New test fixtures needed"]
-
-## 🧪 Acceptance Criteria
-
-**Define what "done" looks like:**
-
-- [ ] Feature works with single card generation
-- [ ] Feature works with sprite sheet generation
-- [ ] Feature works with YAML configuration
-- [x] Feature has comprehensive test coverage
-- [x] Feature is documented in README
-- [x] Feature maintains backward compatibility
-
-## 📋 Additional Context
-
-**Add any other context, screenshots, or examples:**
-
-- **Related Issues:** [e.g. #123, #456]
-- **Community Interest:** [e.g. "Discussed in Discord"]
-- **Similar Features:** [e.g. "Like feature X in other tools"]
+**Screenshots, mockups, or reference images:**
 
 ## 📝 Checklist
 
-- [ ] I have searched existing issues to avoid duplicates
-- [ ] I have provided clear use cases and examples
-- [ ] I have checked if this aligns with project goals
+- [ ] I've searched existing issues to avoid duplicates
+- [ ] This aligns with MTG Card Maker's goals
 
 ---
 
-**Note:** This is a fan-made tool for creating custom MTG cards. Please ensure your feature request complies with Wizards of the Coast's Fan Content Policy and doesn't infringe on their intellectual property.
+**Note:** This is a fan-made tool for creating custom MTG cards. Please ensure your feature request complies with [Wizards of the Coast's Fan Content Policy.](https://company.wizards.com/en/legal/fancontentpolicy)

--- a/README.md
+++ b/README.md
@@ -109,61 +109,61 @@ embed_font: false                 # Optional (default: true)
 Phyrexian, coming soon!
 
 **Mana Symbols:**
-- `W` - White mana <img src="lib/mtg_card_maker/icons/white.svg" width="16" valign="middle" />
-- `B` - Black mana <img src="lib/mtg_card_maker/icons/black.svg" width="16" valign="middle" />
-- `R` - Red mana <img src="lib/mtg_card_maker/icons/red.svg" width="16" valign="middle" />
-- `G` - Green mana <img src="lib/mtg_card_maker/icons/green.svg" width="16" valign="middle" />
-- `U` - Blue mana <img src="lib/mtg_card_maker/icons/blue.svg" width="16" valign="middle" />
-- `C` - Colorless mana <img src="lib/mtg_card_maker/icons/colorless.svg" width="16" valign="middle" />
-- `S` - Snow mana <img src="lib/mtg_card_maker/icons/snow.svg" width="16" valign="middle" />
+- `W` - White mana <img src="images/icons/white.svg" width="16" valign="middle" />
+- `B` - Black mana <img src="images/icons/black.svg" width="16" valign="middle" />
+- `R` - Red mana <img src="images/icons/red.svg" width="16" valign="middle" />
+- `G` - Green mana <img src="images/icons/green.svg" width="16" valign="middle" />
+- `U` - Blue mana <img src="images/icons/blue.svg" width="16" valign="middle" />
+- `C` - Colorless mana <img src="images/icons/colorless.svg" width="16" valign="middle" />
+- `S` - Snow mana <img src="images/icons/snow.svg" width="16" valign="middle" />
 
 **Numeric Symbols:**
-- `0` through `99` - Generic mana costs (0-99) <img src="lib/mtg_card_maker/icons/single-digit.svg" width="16" valign="middle" />
-- `X` - X symbol <img src="lib/mtg_card_maker/icons/x.svg" width="16" valign="middle" />
+- `0` through `99` - Generic mana costs (0-99) <img src="images/icons/single-digit.svg" width="16" valign="middle" />
+- `X` - X symbol <img src="images/icons/x.svg" width="16" valign="middle" />
 
 **Combination Examples:**
-- `16US` - 16 generic + 1 blue + 1 snow <img src="lib/mtg_card_maker/icons/double-digit.svg" width="16" valign="middle" /> <img src="lib/mtg_card_maker/icons/blue.svg" width="16" valign="middle" /> <img src="lib/mtg_card_maker/icons/snow.svg" width="16" valign="middle" />
-- `XG` - X generic + 1 green <img src="lib/mtg_card_maker/icons/x.svg" width="16" valign="middle" /> <img src="lib/mtg_card_maker/icons/green.svg" width="16" valign="middle" />
-- `X3R` - X generic + 3 generic + 1 red <img src="lib/mtg_card_maker/icons/x.svg" width="16" valign="middle" /> <img src="lib/mtg_card_maker/icons/single-digit.svg" width="16" valign="middle" /> <img src="lib/mtg_card_maker/icons/red.svg" width="16" valign="middle" />
-- `3WU` - 3 generic + 1 white + 1 blue <img src="lib/mtg_card_maker/icons/single-digit.svg" width="16" valign="middle" /> <img src="lib/mtg_card_maker/icons/white.svg" width="16" valign="middle" /> <img src="lib/mtg_card_maker/icons/blue.svg" width="16" valign="middle" />
-- `X` - X generic only <img src="lib/mtg_card_maker/icons/x.svg" width="16" valign="middle" />
-- `3` - 3 generic only <img src="lib/mtg_card_maker/icons/single-digit.svg" width="16" valign="middle" />
-- `B` - black only <img src="lib/mtg_card_maker/icons/black.svg" width="16" valign="middle" />
+- `16US` - 16 generic + 1 blue + 1 snow <img src="images/icons/double-digit.svg" width="16" valign="middle" /> <img src="images/icons/blue.svg" width="16" valign="middle" /> <img src="images/icons/snow.svg" width="16" valign="middle" />
+- `XG` - X generic + 1 green <img src="images/icons/x.svg" width="16" valign="middle" /> <img src="images/icons/green.svg" width="16" valign="middle" />
+- `X3R` - X generic + 3 generic + 1 red <img src="images/icons/x.svg" width="16" valign="middle" /> <img src="images/icons/single-digit.svg" width="16" valign="middle" /> <img src="images/icons/red.svg" width="16" valign="middle" />
+- `3WU` - 3 generic + 1 white + 1 blue <img src="images/icons/single-digit.svg" width="16" valign="middle" /> <img src="images/icons/white.svg" width="16" valign="middle" /> <img src="images/icons/blue.svg" width="16" valign="middle" />
+- `X` - X generic only <img src="images/icons/x.svg" width="16" valign="middle" />
+- `3` - 3 generic only <img src="images/icons/single-digit.svg" width="16" valign="middle" />
+- `B` - black only <img src="images/icons/black.svg" width="16" valign="middle" />
 
 **Symbols Available in Rules Text:**
 
 You can use MTG symbols in your rules text by wrapping them in curly braces "{C}". The following symbols are supported:
 
 **Mana Symbols:**
-- `{W}` - White mana <img src="lib/mtg_card_maker/icons/white.svg" width="16" valign="middle" />
-- `{B}` - Black mana <img src="lib/mtg_card_maker/icons/black.svg" width="16" valign="middle" />
-- `{R}` - Red mana <img src="lib/mtg_card_maker/icons/red.svg" width="16" valign="middle" />
-- `{G}` - Green mana <img src="lib/mtg_card_maker/icons/green.svg" width="16" valign="middle" />
-- `{U}` - Blue mana <img src="lib/mtg_card_maker/icons/blue.svg" width="16" valign="middle" />
-- `{C}` - Colorless mana <img src="lib/mtg_card_maker/icons/colorless.svg" width="16" valign="middle" />
-- `{S}` - Snow mana symbol <img src="lib/mtg_card_maker/icons/snow.svg" width="16" valign="middle" />
+- `{W}` - White mana <img src="images/icons/white.svg" width="16" valign="middle" />
+- `{B}` - Black mana <img src="images/icons/black.svg" width="16" valign="middle" />
+- `{R}` - Red mana <img src="images/icons/red.svg" width="16" valign="middle" />
+- `{G}` - Green mana <img src="images/icons/green.svg" width="16" valign="middle" />
+- `{U}` - Blue mana <img src="images/icons/blue.svg" width="16" valign="middle" />
+- `{C}` - Colorless mana <img src="images/icons/colorless.svg" width="16" valign="middle" />
+- `{S}` - Snow mana symbol <img src="images/icons/snow.svg" width="16" valign="middle" />
 
 **Numeric Symbols:**
-- `{0}` through `{99}` - Generic mana costs (0-99) <img src="lib/mtg_card_maker/icons/single-digit.svg" width="16" valign="middle" />
-- `{X}` - X symbol <img src="lib/mtg_card_maker/icons/x.svg" width="16" valign="middle" />
+- `{0}` through `{99}` - Generic mana costs (0-99) <img src="images/icons/single-digit.svg" width="16" valign="middle" />
+- `{X}` - X symbol <img src="images/icons/x.svg" width="16" valign="middle" />
 
 **Special Symbols:**
-- `{T}` - Tap symbol <img src="lib/mtg_card_maker/icons/tap.svg" width="16" valign="middle" />
-- `{Q}` - Untap symbol <img src="lib/mtg_card_maker/icons/untap.svg" width="16" valign="middle" />
-- `{E}` - Energy symbol <img src="lib/mtg_card_maker/icons/energy.svg" width="16" valign="middle" />
+- `{T}` - Tap symbol <img src="images/icons/tap.svg" width="16" valign="middle" />
+- `{Q}` - Untap symbol <img src="images/icons/untap.svg" width="16" valign="middle" />
+- `{E}` - Energy symbol <img src="images/icons/energy.svg" width="16" valign="middle" />
 
 **Example Usage:**
 ```yaml
 rules_text: "{T}: Add {W} or {U} to your mana pool."
 ```
 <p align=center>
-  <img src="lib/mtg_card_maker/icons/tap.svg"
+  <img src="images/icons/tap.svg"
        alt="{T}" width="16" valign="middle" />
   : Add
-  <img src="lib/mtg_card_maker/icons/white.svg"
+  <img src="images/icons/white.svg"
        alt="{W}" width="16" valign="middle" />
   or
-  <img src="lib/mtg_card_maker/icons/blue.svg"
+  <img src="images/icons/blue.svg"
        alt="{B}" width="16" valign="middle" />
   to your mana pool
 </p>

--- a/images/icons
+++ b/images/icons
@@ -1,0 +1,1 @@
+../lib/mtg_card_maker/icons


### PR DESCRIPTION
This pull request focuses on improving issue templates and documentation, as well as reorganizing assets for better maintainability. Key changes include simplifying and clarifying the bug report and feature request templates, updating documentation references to icons, and relocating icon assets to a new directory.

### Improvements to issue templates:

* [`.github/ISSUE_TEMPLATE/bug_report.md`](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5L9-R51): Revised headings and descriptions for clarity and conciseness, removed redundant sections, and updated the checklist format for better readability.
* [`.github/ISSUE_TEMPLATE/feature_request.md`](diffhunk://#diff-148870715557a13127284f8aeaa28002ed6b034268af13c5d030ab59fd078220L9-R28): Streamlined the template by simplifying headings, removing overly detailed sections, and focusing on essential information.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R166): Updated all references to mana and special symbols to use the new `images/icons` directory instead of `lib/mtg_card_maker/icons`. This ensures consistency with the new asset structure.

### Asset reorganization:

* [`images/icons`](diffhunk://#diff-887c6ffd6d545f1c6463062ae63681bff8289144d0ad5dd4ccafb2ff5a185fdeR1): Added a symlink pointing to `../lib/mtg_card_maker/icons` to facilitate the transition to the new asset directory while maintaining backward compatibility.