### PR TITLE
fix: enhance SVG initialization and scaling in card rendering

### DIFF
--- a/color_cards_sprite.svg
+++ b/color_cards_sprite.svg
@@ -283,6 +283,7 @@
     <stop offset="100%" stop-color="#CD853F"/>
   </linearGradient>
   <g transform="translate(0, 0)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -338,8 +339,10 @@ The light of justice never fades, even in the
 darkest of times.
 </text>
 </g>
-</g>
+</svg>
+  </g>
   <g transform="translate(660, 0)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -420,8 +423,10 @@ Knowledge flows like water, finding its way through
 any barrier.
 </text>
 </g>
-</g>
+</svg>
+  </g>
   <g transform="translate(1320, 0)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -475,8 +480,10 @@ Death is not the end, but a transformation into
 something darker.
 </text>
 </g>
-</g>
+</svg>
+  </g>
   <g transform="translate(1980, 0)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -538,8 +545,10 @@ exile it instead.
 Fire consumes all, leaving only ash and memory.
 </text>
 </g>
-</g>
+</svg>
+  </g>
   <g transform="translate(0, 910)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -610,8 +619,10 @@ the battlefield tapped.
 4/12
 </text>
 </g>
-</g>
+</svg>
+  </g>
   <g transform="translate(660, 910)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -671,8 +682,10 @@ A piece of jewelry, usually containing a gemstone,
 that can produce mana. Perhaps a Ruby?
 </text>
 </g>
-</g>
+</svg>
+  </g>
   <g transform="translate(1320, 910)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -742,8 +755,10 @@ third person as 'The Equipped One'.
 
 </foreignObject>
 </g>
-</g>
+</svg>
+  </g>
   <g transform="translate(1980, 910)">
+    <svg viewBox="0 0 630 880" width="630" height="880">
 
 
 
@@ -826,5 +841,6 @@ comprehension.
 8/8
 </text>
 </g>
-</g>
+</svg>
+  </g>
 </svg>

--- a/lib/mtg_card_maker.rb
+++ b/lib/mtg_card_maker.rb
@@ -161,7 +161,7 @@ module MtgCardMaker
     def initialize(width: CARD_WIDTH, height: CARD_HEIGHT, embed_font: false)
       @width = width
       @height = height
-      @svg = Victor::SVG.new width: width, height: height
+      @svg = Victor::SVG.new width: width, height: height, viewBox: "0 0 #{width} #{height}"
       embed_font(embed: embed_font)
     end
 

--- a/lib/mtg_card_maker/sprite_sheet_builder.rb
+++ b/lib/mtg_card_maker/sprite_sheet_builder.rb
@@ -65,7 +65,12 @@ module MtgCardMaker
       return unless svg_element
 
       xml.g(transform: "translate(#{position[:x]}, #{position[:y]})") do
-        add_card_children(xml, svg_element, embed_font)
+        # Add the card with its own viewBox for proper scaling
+        xml.svg(viewBox: "0 0 #{CARD_WIDTH} #{CARD_HEIGHT}",
+                width: CARD_WIDTH,
+                height: CARD_HEIGHT) do
+          add_card_children(xml, svg_element, embed_font)
+        end
       end
     end
 

--- a/output_card.svg
+++ b/output_card.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 @font-face {

--- a/spec/fixtures/art_layer.svg
+++ b/spec/fixtures/art_layer.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 /* Font Classes */

--- a/spec/fixtures/border_layer.svg
+++ b/spec/fixtures/border_layer.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 /* Font Classes */

--- a/spec/fixtures/complete_card.svg
+++ b/spec/fixtures/complete_card.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 @font-face {

--- a/spec/fixtures/frame_layer.svg
+++ b/spec/fixtures/frame_layer.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 /* Font Classes */

--- a/spec/fixtures/name_layer.svg
+++ b/spec/fixtures/name_layer.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 /* Font Classes */

--- a/spec/fixtures/power_layer.svg
+++ b/spec/fixtures/power_layer.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 /* Font Classes */

--- a/spec/fixtures/text_box_layer.svg
+++ b/spec/fixtures/text_box_layer.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 /* Font Classes */

--- a/spec/fixtures/type_line_layer.svg
+++ b/spec/fixtures/type_line_layer.svg
@@ -1,4 +1,4 @@
-<svg width="630" height="880" xmlns="http://www.w3.org/2000/svg">
+<svg width="630" height="880" viewBox="0 0 630 880" xmlns="http://www.w3.org/2000/svg">
 
 <style>
 /* Font Classes */


### PR DESCRIPTION
- Updated the SVG initialization in the MtgCardMaker to include a viewBox for proper scaling.
- Modified the sprite sheet builder to wrap card elements in an SVG tag with a viewBox for consistent rendering.
